### PR TITLE
Update all examples for Chrome Canary 94.0.4579.0

### DIFF
--- a/blank.html
+++ b/blank.html
@@ -49,9 +49,9 @@ utils.addDescription(
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    const context = canvas.getContext("gpupresent");
-    const swapChainFormat = await context.getSwapChainPreferredFormat(device);
-    const swapChain = context.configureSwapChain({
+    const context = canvas.getContext("webgpu");
+    const swapChainFormat = context.getPreferredFormat(adapter);
+    const swapChain = context.configure({
         device,
         format: swapChainFormat
     });
@@ -61,17 +61,17 @@ utils.addDescription(
     ////////////////////////////////////
 
     const commandEncoder = device.createCommandEncoder();
-    const textureView = swapChain.getCurrentTexture().createView();
+    const textureView = context.getCurrentTexture().createView();
 
     const renderPass = commandEncoder.beginRenderPass({
         colorAttachments: [{
-            attachment: textureView,
+            view: textureView,
             loadValue: [0, 0, 0, 1]
         }]
     });
     renderPass.endPass();
 
-    device.defaultQueue.submit([commandEncoder.finish()]);
+    device.queue.submit([commandEncoder.finish()]);
 })();
 </script>
 </body>

--- a/blank.html
+++ b/blank.html
@@ -38,9 +38,9 @@ utils.addDescription(
 );
 
 (async () => {
-    ///////////////////////////////////////
-    // Set up device and canvas swap chain
-    ///////////////////////////////////////
+    ////////////////////////////////////
+    // Set up device and canvas context
+    ////////////////////////////////////
 
     const adapter = await navigator.gpu.requestAdapter();
     const device = await adapter.requestDevice();
@@ -50,10 +50,10 @@ utils.addDescription(
     canvas.height = window.innerHeight;
 
     const context = canvas.getContext("webgpu");
-    const swapChainFormat = context.getPreferredFormat(adapter);
-    const swapChain = context.configure({
+    const presentationFormat = context.getPreferredFormat(adapter);
+    context.configure({
         device,
-        format: swapChainFormat
+        format: presentationFormat
     });
 
     ////////////////////////////////////

--- a/cube-texture-lighting.html
+++ b/cube-texture-lighting.html
@@ -64,9 +64,9 @@ utils.addDescription(
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    const context = canvas.getContext("gpupresent");
-    const swapChainFormat = await context.getSwapChainPreferredFormat(device);
-    const swapChain = context.configureSwapChain({
+    const context = canvas.getContext("webgpu");
+    const swapChainFormat = context.getPreferredFormat(adapter);
+    const swapChain = context.configure({
         device,
         format: swapChainFormat
     });
@@ -88,8 +88,8 @@ utils.addDescription(
 
     const textureData = utils.getImageData(img);
 
-    if (typeof device.defaultQueue.writeTexture === "function") {
-        device.defaultQueue.writeTexture(
+    if (typeof device.queue.writeTexture === "function") {
+        device.queue.writeTexture(
             { texture },
             textureData,
             { bytesPerRow: img.width * 4 },
@@ -106,7 +106,7 @@ utils.addDescription(
             usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
         });
 
-        device.defaultQueue.writeBuffer(textureDataBuffer, 0, textureData);
+        device.queue.writeBuffer(textureDataBuffer, 0, textureData);
 
         const textureLoadEncoder = device.createCommandEncoder();
         textureLoadEncoder.copyBufferToTexture({
@@ -121,7 +121,7 @@ utils.addDescription(
             1
         ]);
 
-        device.defaultQueue.submit([textureLoadEncoder.finish()]);
+        device.queue.submit([textureLoadEncoder.finish()]);
     }
     
     ////////////////////////////////////////
@@ -144,9 +144,9 @@ utils.addDescription(
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
     });
 
-    device.defaultQueue.writeBuffer(positionBuffer, 0, cubeData.positions);
-    device.defaultQueue.writeBuffer(normalBuffer, 0, cubeData.normals);
-    device.defaultQueue.writeBuffer(uvBuffer, 0, cubeData.uvs);
+    device.queue.writeBuffer(positionBuffer, 0, cubeData.positions);
+    device.queue.writeBuffer(normalBuffer, 0, cubeData.normals);
+    device.queue.writeBuffer(uvBuffer, 0, cubeData.uvs);
 
     /////////////////
     // Uniform data
@@ -180,31 +180,39 @@ utils.addDescription(
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
     });
 
-    device.defaultQueue.writeBuffer(vertexUniformBuffer, 64, viewProjectionMatrix);
-    device.defaultQueue.writeBuffer(fragmentUniformBuffer, 0, eyePosition);
-    device.defaultQueue.writeBuffer(fragmentUniformBuffer, 16, lightPosition);
+    device.queue.writeBuffer(vertexUniformBuffer, 64, viewProjectionMatrix);
+    device.queue.writeBuffer(fragmentUniformBuffer, 0, eyePosition);
+    device.queue.writeBuffer(fragmentUniformBuffer, 16, lightPosition);
 
     const sceneUniformBindGroupLayout = device.createBindGroupLayout({
         entries: [
             {
                 binding: 0,
                 visibility: GPUShaderStage.VERTEX,
-                type: "uniform-buffer"
+                buffer: {
+                    type: "uniform"
+                }
             },
             {
                 binding: 1,
                 visibility: GPUShaderStage.FRAGMENT,
-                type: "uniform-buffer"
+                buffer: {
+                    type: "uniform"
+                }
             },
             {
                 binding: 2,
                 visibility: GPUShaderStage.FRAGMENT,
-                type: "sampler"
+                sampler: {
+                    type: "filtering"
+                }
             },
             {
                 binding: 3,
                 visibility: GPUShaderStage.FRAGMENT,
-                type: "sampled-texture"
+                texture: {
+                    sampleType: "float"
+                }
             }
         ]
     });
@@ -298,31 +306,17 @@ utils.addDescription(
 
     const pipeline = device.createRenderPipeline({
         layout: device.createPipelineLayout({bindGroupLayouts: [sceneUniformBindGroupLayout]}),
-        vertexStage: {
+        vertex: {
             module: device.createShaderModule({
                 code: glslang.compileGLSL(vs, "vertex")
             }),
-            entryPoint: "main"
-        },
-        fragmentStage: {
-            module: device.createShaderModule({
-                code: glslang.compileGLSL(fs, "fragment")
-            }),
-            entryPoint: "main"
-        },
-        primitiveTopology: "triangle-list",
-        depthStencilState: {
-            format: "depth24plus",
-            depthWriteEnabled: true,
-            depthCompare: "less"
-        },
-        vertexState: {
-            vertexBuffers: [
+            entryPoint: "main",
+            buffers: [
                 {
                     arrayStride: 12,
                     attributes: [{
                         shaderLocation: 0,
-                        format: "float3",
+                        format: "float32x3",
                         offset: 0
                     }]
                 },
@@ -330,7 +324,7 @@ utils.addDescription(
                     arrayStride: 12,
                     attributes: [{
                         shaderLocation: 1,
-                        format: "float3",
+                        format: "float32x3",
                         offset: 0
                     }]
                 },
@@ -338,15 +332,29 @@ utils.addDescription(
                     arrayStride: 8,
                     attributes: [{
                         shaderLocation: 2,
-                        format: "float2",
+                        format: "float32x2",
                         offset: 0
                     }]
                 }
             ]
         },
-        colorStates: [{
-            format: swapChainFormat
-        }]
+        fragment: {
+            module: device.createShaderModule({
+                code: glslang.compileGLSL(fs, "fragment")
+            }),
+            entryPoint: "main",
+            targets: [{
+                format: swapChainFormat
+            }]
+        },
+        primitive: {
+            topology: "triangle-list",
+        },
+        depthStencil: {
+            format: "depth24plus",
+            depthWriteEnabled: true,
+            depthCompare: "less"
+        }
     });
 
     ///////////////////////////
@@ -356,16 +364,16 @@ utils.addDescription(
     const depthTexture = device.createTexture({
         size: [canvas.width, canvas.height, 1],
         format: "depth24plus",
-        usage:  GPUTextureUsage.OUTPUT_ATTACHMENT
+        usage:  GPUTextureUsage.RENDER_ATTACHMENT
     })
 
     const renderPassDescription = {
         colorAttachments: [{
-            attachment: swapChain.getCurrentTexture().createView(),
+            view: context.getCurrentTexture().createView(),
             loadValue: [0, 0, 0, 1]
         }],
         depthStencilAttachment: {
-            attachment: depthTexture.createView(),
+            view: depthTexture.createView(),
             depthLoadValue: 1,
             depthStoreOp: "store",
             stencilLoadValue: 0,
@@ -382,13 +390,13 @@ utils.addDescription(
         rotation[2] += 0.005;
         utils.xformMatrix(modelMatrix, null, rotation, null);
         
-        device.defaultQueue.writeBuffer(vertexUniformBuffer, 0, modelMatrix);
+        device.queue.writeBuffer(vertexUniformBuffer, 0, modelMatrix);
 
         ////////////////////
         // Swap framebuffer
         ////////////////////
 
-        renderPassDescription.colorAttachments[0].attachment = swapChain.getCurrentTexture().createView();
+        renderPassDescription.colorAttachments[0].view = context.getCurrentTexture().createView();
 
         const commandEncoder = device.createCommandEncoder();
         const renderPass = commandEncoder.beginRenderPass(renderPassDescription);
@@ -408,7 +416,7 @@ utils.addDescription(
         renderPass.draw(numVertices, 1, 0, 0);
         renderPass.endPass();
 
-        device.defaultQueue.submit([commandEncoder.finish()]);
+        device.queue.submit([commandEncoder.finish()]);
 
         requestAnimationFrame(draw);
     });

--- a/cube-texture-lighting.html
+++ b/cube-texture-lighting.html
@@ -54,9 +54,9 @@ utils.addDescription(
         img.decode()
     ]);
 
-    ///////////////////////////////////////
-    // Set up device and canvas swap chain
-    ///////////////////////////////////////
+    ////////////////////////////////////
+    // Set up device and canvas context
+    ////////////////////////////////////
 
     const device = await adapter.requestDevice();
     
@@ -65,10 +65,10 @@ utils.addDescription(
     canvas.height = window.innerHeight;
 
     const context = canvas.getContext("webgpu");
-    const swapChainFormat = context.getPreferredFormat(adapter);
-    const swapChain = context.configure({
+    const presentationFormat = context.getPreferredFormat(adapter);
+    context.configure({
         device,
-        format: swapChainFormat
+        format: presentationFormat
     });
 
     /////////////////////////////////////////
@@ -344,7 +344,7 @@ utils.addDescription(
             }),
             entryPoint: "main",
             targets: [{
-                format: swapChainFormat
+                format: presentationFormat
             }]
         },
         primitive: {

--- a/cube.html
+++ b/cube.html
@@ -59,9 +59,9 @@ utils.addDescription(
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    const context = canvas.getContext("gpupresent");
-    const swapChainFormat = await context.getSwapChainPreferredFormat(device);
-    const swapChain = context.configureSwapChain({
+    const context = canvas.getContext("webgpu");
+    const swapChainFormat = context.getPreferredFormat(adapter);
+    const swapChain = context.configure({
         device,
         format: swapChainFormat
     });
@@ -82,8 +82,8 @@ utils.addDescription(
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
     });
 
-    device.defaultQueue.writeBuffer(positionBuffer, 0, cubeData.positions);
-    device.defaultQueue.writeBuffer(normalBuffer, 0, cubeData.normals);
+    device.queue.writeBuffer(positionBuffer, 0, cubeData.positions);
+    device.queue.writeBuffer(normalBuffer, 0, cubeData.normals);
 
     /////////////////
     // Uniform data
@@ -113,7 +113,9 @@ utils.addDescription(
         entries: [{
             binding: 0,
             visibility: GPUShaderStage.VERTEX,
-            type: "uniform-buffer"
+            buffer: {
+                type: "uniform"
+            }
         }]
     });
 
@@ -164,31 +166,17 @@ utils.addDescription(
 
     const pipeline = device.createRenderPipeline({
         layout: device.createPipelineLayout({bindGroupLayouts: [sceneUniformBindGroupLayout]}),
-        vertexStage: {
+        vertex: {
             module: device.createShaderModule({
                 code: glslang.compileGLSL(vs, "vertex")
             }),
-            entryPoint: "main"
-        },
-        fragmentStage: {
-            module: device.createShaderModule({
-                code: glslang.compileGLSL(fs, "fragment")
-            }),
-            entryPoint: "main"
-        },
-        primitiveTopology: "triangle-list",
-        depthStencilState: {
-            format: "depth24plus",
-            depthWriteEnabled: true,
-            depthCompare: "less"
-        },
-        vertexState: {
-            vertexBuffers: [
+            entryPoint: "main",
+            buffers: [
                 {
                     arrayStride: 12,
                     attributes: [{
                         shaderLocation: 0,
-                        format: "float3",
+                        format: "float32x3",
                         offset: 0
                     }]
                 },
@@ -196,15 +184,29 @@ utils.addDescription(
                     arrayStride: 12,
                     attributes: [{
                         shaderLocation: 1,
-                        format: "float3",
+                        format: "float32x3",
                         offset: 0
                     }]
                 }
             ]
         },
-        colorStates: [{
-            format: swapChainFormat
-        }]
+        fragment: {
+            module: device.createShaderModule({
+                code: glslang.compileGLSL(fs, "fragment")
+            }),
+            entryPoint: "main",
+            targets: [{
+                format: swapChainFormat
+            }]
+        },
+        primitive: {
+            topology: "triangle-list",
+        },
+        depthStencil: {
+            format: "depth24plus",
+            depthWriteEnabled: true,
+            depthCompare: "less"
+        }
     });
 
     ///////////////////////////
@@ -214,16 +216,16 @@ utils.addDescription(
     const depthTexture = device.createTexture({
         size: [canvas.width, canvas.height, 1],
         format: "depth24plus",
-        usage:  GPUTextureUsage.OUTPUT_ATTACHMENT
+        usage:  GPUTextureUsage.RENDER_ATTACHMENT
     });
 
     const renderPassDescription = {
         colorAttachments: [{
-            attachment: swapChain.getCurrentTexture().createView(),
+            view: context.getCurrentTexture().createView(),
             loadValue: [0, 0, 0, 1]
         }],
         depthStencilAttachment: {
-            attachment: depthTexture.createView(),
+            view: depthTexture.createView(),
             depthLoadValue: 1,
             depthStoreOp: "store",
             stencilLoadValue: 0,
@@ -241,13 +243,13 @@ utils.addDescription(
         utils.xformMatrix(modelMatrix, null, rotation, null);
         mat4.multiply(mvpMatrix, viewProjectionMatrix, modelMatrix);
         
-        device.defaultQueue.writeBuffer(sceneUniformBuffer, 0, mvpMatrix);
+        device.queue.writeBuffer(sceneUniformBuffer, 0, mvpMatrix);
 
         ////////////////////
         // Swap framebuffer
         ////////////////////
 
-        renderPassDescription.colorAttachments[0].attachment = swapChain.getCurrentTexture().createView();
+        renderPassDescription.colorAttachments[0].view = context.getCurrentTexture().createView();
 
         ////////////////////////////////////
         // Create and submit command buffer
@@ -270,7 +272,7 @@ utils.addDescription(
         renderPass.draw(numVertices, 1, 0, 0);
         renderPass.endPass();
 
-        device.defaultQueue.submit([commandEncoder.finish()]);
+        device.queue.submit([commandEncoder.finish()]);
 
         requestAnimationFrame(draw);
     });

--- a/cube.html
+++ b/cube.html
@@ -49,9 +49,9 @@ utils.addDescription(
         import("https://unpkg.com/@webgpu/glslang@0.0.7/web/glslang.js").then(m => m.default())
     ]);
 
-    ///////////////////////////////////////
-    // Set up device and canvas swap chain
-    ///////////////////////////////////////
+    ////////////////////////////////////
+    // Set up device and canvas context
+    ////////////////////////////////////
 
     const device = await adapter.requestDevice();
     
@@ -60,10 +60,10 @@ utils.addDescription(
     canvas.height = window.innerHeight;
 
     const context = canvas.getContext("webgpu");
-    const swapChainFormat = context.getPreferredFormat(adapter);
-    const swapChain = context.configure({
+    const presentationFormat = context.getPreferredFormat(adapter);
+    context.configure({
         device,
-        format: swapChainFormat
+        format: presentationFormat
     });
 
     ////////////////////////////////////////
@@ -196,7 +196,7 @@ utils.addDescription(
             }),
             entryPoint: "main",
             targets: [{
-                format: swapChainFormat
+                format: presentationFormat
             }]
         },
         primitive: {

--- a/particles.html
+++ b/particles.html
@@ -62,9 +62,9 @@ utils.addDescription(
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    const context = canvas.getContext("gpupresent");
-    const swapChainFormat = await context.getSwapChainPreferredFormat(device);
-    const swapChain = context.configureSwapChain({
+    const context = canvas.getContext("webgpu");
+    const swapChainFormat = await context.getPreferredFormat(adapter);
+    const swapChain = context.configure({
         device,
         format: swapChainFormat
     });
@@ -74,11 +74,12 @@ utils.addDescription(
     // (input/output pair of position and velocity buffers)
     ////////////////////////////////////////////////////////
 
-    const [positionBufferA, positionBufferMap] = device.createBufferMapped({
+    const positionBufferA = device.createBuffer({
         size: 16 * NUM_PARTICLES,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+        mappedAtCreation: true
     });
-    const positionBufferData = new Float32Array(positionBufferMap);
+    const positionBufferData = new Float32Array(positionBufferA.getMappedRange());
     for (let i = 0; i < positionBufferData.length; i += 4) {
         positionBufferData[i]     = Math.random() * 2 - 1;
         positionBufferData[i + 1] = Math.random() * 2 - 1;
@@ -87,11 +88,12 @@ utils.addDescription(
     }
     positionBufferA.unmap();
 
-    const [velocityBufferA, velocityBufferMap] = device.createBufferMapped({
+    const velocityBufferA = device.createBuffer({
         size: 16 * NUM_PARTICLES,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+        mappedAtCreation: true
     });
-    const velocityBufferData = new Float32Array(velocityBufferMap);
+    const velocityBufferData = new Float32Array(velocityBufferA.getMappedRange());
     for (let i = 0; i < velocityBufferData.length; i += 4) {
         velocityBufferData[i]     = Math.random() * 0.002 - 0.001;
         velocityBufferData[i + 1] = Math.random() * 0.002 - 0.001;
@@ -114,11 +116,12 @@ utils.addDescription(
     // Create buffers for render pass
     ///////////////////////////////////
 
-    const [vertexBuffer, vertexBufferMap] = device.createBufferMapped({
+    const vertexBuffer = device.createBuffer({
         size: 32,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
     });
-    new Float32Array(vertexBufferMap).set([
+    new Float32Array(vertexBuffer.getMappedRange()).set([
         -1.0, -1.0,
         1.0, -1.0,
         -1.0, 1.0,
@@ -126,11 +129,12 @@ utils.addDescription(
     ]);
     vertexBuffer.unmap();
 
-    const [colorBuffer, colorBufferMap] = device.createBufferMapped({
+    const colorBuffer = device.createBuffer({
         size: 4 * NUM_PARTICLES,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+        mappedAtCreation: true
     });
-    const colorBufferData = new Uint8Array(colorBufferMap);
+    const colorBufferData = new Uint8Array(colorBuffer.getMappedRange());
     for (let i = 0; i < colorBufferData.length; i += 4) {
         colorBufferData[i]     = Math.floor(Math.random() * 256);
         colorBufferData[i + 1] = Math.floor(Math.random() * 256);
@@ -155,7 +159,7 @@ utils.addDescription(
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
     });
 
-    computeUniformBuffer.setSubData(0, computeUniformData);
+    device.queue.writeBuffer(computeUniformBuffer, 0, computeUniformData);
 
     //////////////////////////////////////////////////////////
     // Compute binding layouts 
@@ -168,27 +172,37 @@ utils.addDescription(
             {
                 binding: 0,
                 visibility: GPUShaderStage.COMPUTE,
-                type: "storage-buffer"
+                buffer: {
+                    type: "storage"
+                }
             },
             {
                 binding: 1,
                 visibility: GPUShaderStage.COMPUTE,
-                type: "storage-buffer"
+                buffer: {
+                    type: "storage"
+                }
             },
             {
                 binding: 2,
                 visibility: GPUShaderStage.COMPUTE,
-                type: "storage-buffer"
+                buffer: {
+                    type: "storage"
+                }
             },
             {
                 binding: 3,
                 visibility: GPUShaderStage.COMPUTE,
-                type: "storage-buffer"
+                buffer: {
+                    type: "storage"
+                }
             },
             {
                 binding: 4,
                 visibility: GPUShaderStage.COMPUTE,
-                type: "uniform-buffer"
+                buffer: {
+                    type: "uniform"
+                }
             }
         ]
     });
@@ -316,15 +330,15 @@ utils.addDescription(
         velocity += acceleration;
         velocity *= 0.9999;
 
-        positionsOut[index].xyz = position + velocity;
-        velocityOut[index].xyz = velocity;
+        positionsOut[index] = vec4(position + velocity, 1);
+        velocityOut[index] = vec4(velocity, 1);
     }
 
     `.trim();
 
     const computePipeline = device.createComputePipeline({
         layout: device.createPipelineLayout({bindGroupLayouts: [computeBindGroupLayout]}),
-        computeStage: {
+        compute: {
             module: device.createShaderModule({
                 code: glslang.compileGLSL(cs, "compute")
             }),
@@ -341,7 +355,7 @@ utils.addDescription(
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
     });
 
-    vertexUniformBuffer.setSubData(0, new Float32Array([
+    device.queue.writeBuffer(vertexUniformBuffer, 0, new Float32Array([
         canvas.width, canvas.height, PARTICLE_SIZE
     ]));
 
@@ -349,7 +363,9 @@ utils.addDescription(
         entries: [{
             binding: 0,
             visibility: GPUShaderStage.VERTEX,
-            type: "uniform-buffer"
+            buffer: {
+                type: "uniform"
+            }
         }]
     });
 
@@ -402,26 +418,17 @@ utils.addDescription(
 
     const renderPipeline = device.createRenderPipeline({
         layout: device.createPipelineLayout({bindGroupLayouts: [vertexUniformBindGroupLayout]}),
-        vertexStage: {
+        vertex: {
             module: device.createShaderModule({
                 code: glslang.compileGLSL(vs, "vertex")
             }),
-            entryPoint: "main"
-        },
-        fragmentStage: {
-            module: device.createShaderModule({
-                code: glslang.compileGLSL(fs, "fragment")
-            }),
-            entryPoint: "main"
-        },
-        primitiveTopology: "triangle-strip",
-        vertexState: {
-            vertexBuffers: [
+            entryPoint: "main",
+            buffers: [
                 {
                     arrayStride: 8,
                     attributes: [{
                         shaderLocation: 0,
-                        format: "float2",
+                        format: "float32x2",
                         offset: 0
                     }]
                 },
@@ -430,7 +437,7 @@ utils.addDescription(
                     stepMode: "instance",
                     attributes: [{
                         shaderLocation: 1,
-                        format: "uchar4norm",
+                        format: "unorm8x4",
                         offset: 0
                     }]
                 },
@@ -439,23 +446,33 @@ utils.addDescription(
                     stepMode: "instance",
                     attributes: [{
                         shaderLocation: 2,
-                        format: "float4",
+                        format: "float32x4",
                         offset: 0
                     }]
                 }
             ]
         },
-        colorStates: [{
-            format: swapChainFormat,
-            colorBlend: {
-                srcFactor: "one",
-                dstFactor: "one-minus-src-alpha"
-            },
-            alphaBlend: {
-                srcFactor: "one",
-                dstFactor: "one-minus-src-alpha"
-            }
-        }]
+        fragment: {
+            module: device.createShaderModule({
+                code: glslang.compileGLSL(fs, "fragment")
+            }),
+            entryPoint: "main",
+            targets: [{
+                format: swapChainFormat,
+                colorBlend: {
+                    srcFactor: "one",
+                    dstFactor: "one-minus-src-alpha"
+                },
+                alphaBlend: {
+                    srcFactor: "one",
+                    dstFactor: "one-minus-src-alpha"
+                }
+            }]
+        },
+        primitive: {
+            topology: "triangle-strip",
+            stripIndexFormat: "uint32"
+        }
     });
 
     ///////////////////////////
@@ -464,7 +481,7 @@ utils.addDescription(
 
     const renderPassDescriptor = {
         colorAttachments: [{
-            attachment: swapChain.getCurrentTexture().createView(),
+            view: context.getCurrentTexture().createView(),
             loadValue: [0, 0, 0, 1]
         }]
     };
@@ -502,7 +519,7 @@ utils.addDescription(
         // Swap framebuffer
         ////////////////////
 
-        renderPassDescriptor.colorAttachments[0].attachment = swapChain.getCurrentTexture().createView();
+        renderPassDescriptor.colorAttachments[0].view = context.getCurrentTexture().createView();
 
         ///////////////////////
         // Encode render pass
@@ -528,7 +545,7 @@ utils.addDescription(
         // Submit command buffer
         //////////////////////////
 
-        device.defaultQueue.submit([commandEncoder.finish()]);
+        device.queue.submit([commandEncoder.finish()]);
     
         /////////////////
         // Swap buffers

--- a/particles.html
+++ b/particles.html
@@ -52,9 +52,9 @@ utils.addDescription(
         import("https://unpkg.com/@webgpu/glslang@0.0.7/web/glslang.js").then(m => m.default())
     ]);
 
-    ///////////////////////////////////////
-    // Set up device and canvas swap chain
-    ///////////////////////////////////////
+    ////////////////////////////////////
+    // Set up device and canvas context
+    ////////////////////////////////////
 
     const device = await adapter.requestDevice();
     
@@ -63,10 +63,10 @@ utils.addDescription(
     canvas.height = window.innerHeight;
 
     const context = canvas.getContext("webgpu");
-    const swapChainFormat = await context.getPreferredFormat(adapter);
-    const swapChain = context.configure({
+    const presentationFormat = await context.getPreferredFormat(adapter);
+    context.configure({
         device,
-        format: swapChainFormat
+        format: presentationFormat
     });
 
     ////////////////////////////////////////////////////////
@@ -458,7 +458,7 @@ utils.addDescription(
             }),
             entryPoint: "main",
             targets: [{
-                format: swapChainFormat,
+                format: presentationFormat,
                 colorBlend: {
                     srcFactor: "one",
                     dstFactor: "one-minus-src-alpha"

--- a/point.html
+++ b/point.html
@@ -59,9 +59,9 @@ utils.addDescription(
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    const context = canvas.getContext("gpupresent");
-    const swapChainFormat = await context.getSwapChainPreferredFormat(device);
-    const swapChain = context.configureSwapChain({
+    const context = canvas.getContext("webgpu");
+    const swapChainFormat = context.getPreferredFormat(adapter);
+    const swapChain = context.configure({
         device,
         format: swapChainFormat
     });
@@ -89,22 +89,24 @@ utils.addDescription(
     `.trim();
 
     const pipeline = device.createRenderPipeline({
-        vertexStage: {
+        vertex: {
             module: device.createShaderModule({
                 code: glslang.compileGLSL(vs, "vertex")
             }),
             entryPoint: "main"
         },
-        fragmentStage: {
+        fragment: {
             module: device.createShaderModule({
                 code: glslang.compileGLSL(fs, "fragment")
             }),
-            entryPoint: "main"
+            entryPoint: "main",
+            targets: [{
+                format: swapChainFormat
+            }]
         },
-        primitiveTopology: "point-list",
-        colorStates: [{
-            format: swapChainFormat
-        }]
+        primitive: {
+            topology: "point-list"
+        }
     });
 
     ////////////////////////////////////
@@ -112,11 +114,11 @@ utils.addDescription(
     ////////////////////////////////////
 
     const commandEncoder = device.createCommandEncoder();
-    const textureView = swapChain.getCurrentTexture().createView();
+    const textureView = context.getCurrentTexture().createView();
 
     const renderPass = commandEncoder.beginRenderPass({
         colorAttachments: [{
-            attachment: textureView,
+            view: textureView,
             loadValue: [0, 0, 0, 1]
         }]
     });
@@ -124,7 +126,7 @@ utils.addDescription(
     renderPass.draw(1, 1, 0, 0);
     renderPass.endPass();
 
-    device.defaultQueue.submit([commandEncoder.finish()]);
+    device.queue.submit([commandEncoder.finish()]);
 })();
 </script>
 </body>

--- a/point.html
+++ b/point.html
@@ -49,9 +49,9 @@ utils.addDescription(
         import("https://unpkg.com/@webgpu/glslang@0.0.7/web/glslang.js").then(m => m.default())
     ]);
 
-    ///////////////////////////////////////
-    // Set up device and canvas swap chain
-    ///////////////////////////////////////
+    ////////////////////////////////////
+    // Set up device and canvas context
+    ////////////////////////////////////
 
     const device = await adapter.requestDevice();
 
@@ -60,10 +60,10 @@ utils.addDescription(
     canvas.height = window.innerHeight;
 
     const context = canvas.getContext("webgpu");
-    const swapChainFormat = context.getPreferredFormat(adapter);
-    const swapChain = context.configure({
+    const presentationFormat = context.getPreferredFormat(adapter);
+    context.configure({
         device,
-        format: swapChainFormat
+        format: presentationFormat
     });
 
     /////////////////////////////////////////////////
@@ -101,7 +101,7 @@ utils.addDescription(
             }),
             entryPoint: "main",
             targets: [{
-                format: swapChainFormat
+                format: presentationFormat
             }]
         },
         primitive: {

--- a/triangle.html
+++ b/triangle.html
@@ -58,9 +58,9 @@ utils.addDescription(
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    const context = canvas.getContext("gpupresent");
-    const swapChainFormat = await context.getSwapChainPreferredFormat(device);
-    const swapChain = context.configureSwapChain({
+    const context = canvas.getContext("webgpu");
+    const swapChainFormat = context.getPreferredFormat(adapter);
+    const swapChain = context.configure({
         device,
         format: swapChainFormat
     });
@@ -69,22 +69,24 @@ utils.addDescription(
     // Create vertex buffers and load data
     ////////////////////////////////////////
 
-    const [positionBuffer, positionBufferMap] = device.createBufferMapped({
+    const positionBuffer = device.createBuffer({
         size: 24,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
     });
-    new Float32Array(positionBufferMap).set([
+    new Float32Array(positionBuffer.getMappedRange()).set([
         -0.5, -0.5,
         0.5, -0.5,
         0.0, 0.5
     ]);
     positionBuffer.unmap();
 
-    const [colorBuffer, colorBufferMap] = device.createBufferMapped({
+    const colorBuffer = device.createBuffer({
         size: 12,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
     });
-    new Uint8Array(colorBufferMap).set([
+    new Uint8Array(colorBuffer.getMappedRange()).set([
         255, 0, 0, 255,
         0, 255, 0, 255,
         0, 0, 255, 255
@@ -122,26 +124,17 @@ utils.addDescription(
     `.trim();
 
     const pipeline = device.createRenderPipeline({
-        vertexStage: {
+        vertex: {
             module: device.createShaderModule({
                 code: glslang.compileGLSL(vs, "vertex")
             }),
-            entryPoint: "main"
-        },
-        fragmentStage: {
-            module: device.createShaderModule({
-                code: glslang.compileGLSL(fs, "fragment")
-            }),
-            entryPoint: "main"
-        },
-        primitiveTopology: "triangle-list",
-        vertexState: {
-            vertexBuffers: [
+            entryPoint: "main",
+            buffers: [
                 {
                     arrayStride: 8,
                     attributes: [{
                         shaderLocation: 0,
-                        format: "float2",
+                        format: "float32x2",
                         offset: 0
                     }]
                 },
@@ -149,15 +142,24 @@ utils.addDescription(
                     arrayStride: 4,
                     attributes: [{
                         shaderLocation: 1,
-                        format: "uchar4norm",
+                        format: "unorm8x4",
                         offset: 0
                     }]
                 }
             ]
         },
-        colorStates: [{
-            format: swapChainFormat
-        }]
+        fragment: {
+            module: device.createShaderModule({
+                code: glslang.compileGLSL(fs, "fragment")
+            }),
+            entryPoint: "main",
+            targets: [{
+                format: swapChainFormat
+            }]
+        },
+        primitive: {
+            topology: "triangle-list"
+        }
     });
 
     ////////////////////////////////////
@@ -165,11 +167,11 @@ utils.addDescription(
     ////////////////////////////////////
 
     const commandEncoder = device.createCommandEncoder();
-    const textureView = swapChain.getCurrentTexture().createView();
+    const textureView = context.getCurrentTexture().createView();
 
     const renderPass = commandEncoder.beginRenderPass({
         colorAttachments: [{
-            attachment: textureView,
+            view: textureView,
             loadValue: [0, 0, 0, 1]
         }]
     });
@@ -183,7 +185,7 @@ utils.addDescription(
     renderPass.draw(3, 1, 0, 0);
     renderPass.endPass();
 
-    device.defaultQueue.submit([commandEncoder.finish()]);
+    device.queue.submit([commandEncoder.finish()]);
 })();
 </script>
 </body>

--- a/triangle.html
+++ b/triangle.html
@@ -48,9 +48,9 @@ utils.addDescription(
         import("https://unpkg.com/@webgpu/glslang@0.0.7/web/glslang.js").then(m => m.default())
     ]);
 
-    ///////////////////////////////////////
-    // Set up device and canvas swap chain
-    ///////////////////////////////////////
+    ////////////////////////////////////
+    // Set up device and canvas context
+    ////////////////////////////////////
 
     const device = await adapter.requestDevice();
     
@@ -59,10 +59,10 @@ utils.addDescription(
     canvas.height = window.innerHeight;
 
     const context = canvas.getContext("webgpu");
-    const swapChainFormat = context.getPreferredFormat(adapter);
-    const swapChain = context.configure({
+    const presentationFormat = context.getPreferredFormat(adapter);
+    context.configure({
         device,
-        format: swapChainFormat
+        format: presentationFormat
     });
 
     ////////////////////////////////////////
@@ -154,7 +154,7 @@ utils.addDescription(
             }),
             entryPoint: "main",
             targets: [{
-                format: swapChainFormat
+                format: presentationFormat
             }]
         },
         primitive: {


### PR DESCRIPTION
Conforms to changes in the spec, including:
- Context name (https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext)
- Swap chain setup (https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getpreferredformat and https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure)
- Device queue name (https://gpuweb.github.io/gpuweb/#gpu-device)
- Bind group layout entry type (https://gpuweb.github.io/gpuweb/#dictdef-gpubindgrouplayoutentry)
- Render pipeline structure (https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpipelinedescriptor)
- Attribute formats (https://gpuweb.github.io/gpuweb/#vertex-formats)

Tested on Mac using Chrome Canary 94.0.4579.0

Let me know what you think!

Edit: It looks like there's also some changes to the way binding group layouts work. They can be inferred from the pipeline rather than declared explicitly. I think that might mean a bit of rearrangement, possibly best left for a separate PR?